### PR TITLE
Add OpenAI and Anthropic API support

### DIFF
--- a/app/actions/translate.ts
+++ b/app/actions/translate.ts
@@ -3,6 +3,8 @@
 import { ERROR_TYPES } from "@/utils/constants"
 import { ErrorService } from "@/utils/error-service"
 import { translateWithGemini } from "@/utils/gemini-service"
+import { translateWithOpenAI } from "@/utils/openai-service"
+import { translateWithAnthropic } from "@/utils/anthropic-service"
 
 // Configuração para tentativas
 const MAX_RETRIES = 2
@@ -11,7 +13,14 @@ const RETRY_DELAY = 1000 // ms
 // Função para esperar um tempo específico
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-export async function translateText(text: string, sourceLang = "en", targetLang = "pt", geminiApiKey?: string) {
+export async function translateText(
+  text: string,
+  sourceLang = "en",
+  targetLang = "pt",
+  geminiApiKey?: string,
+  openaiApiKey?: string,
+  anthropicApiKey?: string,
+) {
   if (!text.trim()) {
     return {
       success: false,
@@ -20,58 +29,87 @@ export async function translateText(text: string, sourceLang = "en", targetLang 
     }
   }
 
-  // Se não houver chave de API, retornar erro
-  if (!geminiApiKey) {
+  // Se nenhuma chave de API for fornecida, retornar erro
+  if (!geminiApiKey && !openaiApiKey && !anthropicApiKey) {
     return {
       success: false,
       message: "API key is required",
-      error: ErrorService.createError(ERROR_TYPES.VALIDATION, "Chave de API do Gemini não fornecida"),
+      error: ErrorService.createError(
+        ERROR_TYPES.VALIDATION,
+        "Nenhuma chave de API fornecida",
+      ),
     }
   }
 
-  console.log(`Traduzindo texto: "${text.substring(0, 30)}..." de ${sourceLang} para ${targetLang} usando Gemini`)
+  // Determinar provedor de tradução com base na chave disponível
+  if (geminiApiKey) {
+    console.log(
+      `Traduzindo texto: "${text.substring(0, 30)}..." de ${sourceLang} para ${targetLang} usando Gemini`,
+    )
 
-  // Tentativas com Gemini
-  let geminiError = null
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    if (attempt > 0) {
-      console.log(`Tentativa ${attempt} com Gemini após falha anterior`)
-      await wait(RETRY_DELAY * attempt) // Espera progressivamente mais tempo entre tentativas
-    }
-
-    try {
-      console.log(`Fazendo requisição para Gemini (tentativa ${attempt + 1}/${MAX_RETRIES + 1})`)
-
-      const result = await translateWithGemini(text, sourceLang, targetLang, geminiApiKey)
-
-      if (result.success && result.translation) {
-        console.log(`Tradução recebida do Gemini: "${result.translation.substring(0, 30)}..."`)
-        return result
-      } else {
-        console.error("Erro na tradução com Gemini:", result.message)
-        geminiError = result.error || ErrorService.createError(ERROR_TYPES.API, result.message || "Erro desconhecido")
+    let geminiError = null
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        console.log(`Tentativa ${attempt} com Gemini após falha anterior`)
+        await wait(RETRY_DELAY * attempt)
       }
-    } catch (error) {
-      console.error("Erro ao chamar Gemini:", error)
-      geminiError = ErrorService.createError(
-        ERROR_TYPES.NETWORK,
-        error instanceof Error ? error.message : "Erro desconhecido",
-        { error },
-      )
+
+      try {
+        console.log(
+          `Fazendo requisição para Gemini (tentativa ${attempt + 1}/${MAX_RETRIES + 1})`,
+        )
+        const result = await translateWithGemini(text, sourceLang, targetLang, geminiApiKey)
+        if (result.success && result.translation) {
+          console.log(`Tradução recebida do Gemini: "${result.translation.substring(0, 30)}..."`)
+          return result
+        } else {
+          console.error("Erro na tradução com Gemini:", result.message)
+          geminiError = result.error || ErrorService.createError(
+            ERROR_TYPES.API,
+            result.message || "Erro desconhecido",
+          )
+        }
+      } catch (error) {
+        console.error("Erro ao chamar Gemini:", error)
+        geminiError = ErrorService.createError(
+          ERROR_TYPES.NETWORK,
+          error instanceof Error ? error.message : "Erro desconhecido",
+          { error },
+        )
+      }
     }
+
+    console.log(`Gemini falhou após ${MAX_RETRIES + 1} tentativas. Erro:`, geminiError)
   }
 
-  console.log(`Gemini falhou após ${MAX_RETRIES + 1} tentativas. Erro:`, geminiError)
+  if (openaiApiKey) {
+    console.log(
+      `Traduzindo texto: "${text.substring(0, 30)}..." de ${sourceLang} para ${targetLang} usando OpenAI`,
+    )
+    const result = await translateWithOpenAI(text, sourceLang, targetLang, openaiApiKey)
+    if (result.success && result.translation) {
+      return result
+    }
+    console.error("Falha na tradução com OpenAI:", result.message)
+  }
 
-  // Gemini falhou
+  if (anthropicApiKey) {
+    console.log(
+      `Traduzindo texto: "${text.substring(0, 30)}..." de ${sourceLang} para ${targetLang} usando Anthropic`,
+    )
+    const result = await translateWithAnthropic(text, sourceLang, targetLang, anthropicApiKey)
+    if (result.success && result.translation) {
+      return result
+    }
+    console.error("Falha na tradução com Anthropic:", result.message)
+  }
+
   return {
     success: false,
-    message: `Falha na tradução com Gemini. Verifique sua chave de API e tente novamente.`,
-    details: {
-      geminiError,
-    },
-    error: ErrorService.createError(ERROR_TYPES.API, "Falha na tradução com Gemini", {
-      geminiError,
-    }),
+    message: "Falha na tradução com todos os provedores disponíveis.",
+    error: ErrorService.createError(
+      ERROR_TYPES.API,
+      "Falha na tradução em todos os provedores",
+    ),
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,6 +34,8 @@ export default function TranslationPlatform() {
   const [isLoadingGlossary, setIsLoadingGlossary] = useState(false)
   const [apiSettings, setApiSettings] = useState<ApiSettings>({
     geminiApiKey: "",
+    openaiApiKey: "",
+    anthropicApiKey: "",
     useLocalStorage: true,
   })
 
@@ -181,7 +183,9 @@ export default function TranslationPlatform() {
   }
 
   // Verificar se a chave de API está configurada
-  const isApiKeyConfigured = Boolean(apiSettings.geminiApiKey)
+  const isApiKeyConfigured = Boolean(
+    apiSettings.geminiApiKey || apiSettings.openaiApiKey || apiSettings.anthropicApiKey,
+  )
 
   return (
     <KeyboardShortcutsProvider>
@@ -233,15 +237,14 @@ export default function TranslationPlatform() {
                   {!isApiKeyConfigured ? (
                     <div className="p-6 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800/30 text-center">
                       <h3 className="text-lg font-medium text-amber-800 dark:text-amber-300 mb-2">
-                        Chave de API do Gemini necessária
+                        Chave de API necessária
                       </h3>
                       <p className="text-amber-700 dark:text-amber-400 mb-4">
-                        Para usar a tradução automática, você precisa configurar uma chave de API do Google Gemini.
-                        Clique no botão "API Gemini" na barra de navegação para configurar.
+                        Para usar a tradução automática, configure uma chave de API nos ajustes de API.
+                        Clique no botão "APIs" na barra de navegação para inserir suas chaves do Gemini, OpenAI ou Anthropic.
                       </p>
                       <p className="text-sm text-amber-600 dark:text-amber-500">
-                        Esta aplicação utiliza o modelo Gemini 1.5 Flash para tradução automática. Você ainda pode
-                        editar e traduzir manualmente sem uma chave de API.
+                        Você ainda pode editar e traduzir manualmente sem uma chave de API.
                       </p>
                     </div>
                   ) : (

--- a/components/api-settings-modal.tsx
+++ b/components/api-settings-modal.tsx
@@ -16,6 +16,8 @@ interface ApiSettingsModalProps {
 
 export interface ApiSettings {
   geminiApiKey: string
+  openaiApiKey: string
+  anthropicApiKey: string
   useLocalStorage: boolean
 }
 
@@ -23,6 +25,8 @@ export default function ApiSettingsModal({ isOpen, onClose, onSaveSettings, curr
   const [settings, setSettings] = useState<ApiSettings>({
     ...currentSettings,
     geminiApiKey: currentSettings.geminiApiKey || "",
+    openaiApiKey: currentSettings.openaiApiKey || "",
+    anthropicApiKey: currentSettings.anthropicApiKey || "",
   })
   const [testStatus, setTestStatus] = useState<{
     isLoading: boolean
@@ -153,6 +157,30 @@ export default function ApiSettingsModal({ isOpen, onClose, onSaveSettings, curr
               {testStatus.message}
             </div>
           )}
+        </div>
+
+        <div className="space-y-4 mt-4">
+          <div className="space-y-2">
+            <Label htmlFor="openai-api-key">Chave de API da OpenAI</Label>
+            <Input
+              id="openai-api-key"
+              type="password"
+              value={settings.openaiApiKey}
+              onChange={(e) => setSettings({ ...settings, openaiApiKey: e.target.value })}
+              placeholder="Insira sua chave da OpenAI"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="anthropic-api-key">Chave de API da Anthropic</Label>
+            <Input
+              id="anthropic-api-key"
+              type="password"
+              value={settings.anthropicApiKey}
+              onChange={(e) => setSettings({ ...settings, anthropicApiKey: e.target.value })}
+              placeholder="Insira sua chave da Anthropic"
+            />
+          </div>
         </div>
 
         <div className="flex items-center space-x-2 mt-4">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -28,6 +28,8 @@ export default function Navbar({
   onClearWork,
   apiSettings = {
     geminiApiKey: "AIzaSyB5ANmjzUj251i2G3FHgV7UEV9NH4OwT18",
+    openaiApiKey: "",
+    anthropicApiKey: "",
     useLocalStorage: true,
   },
 }: NavbarProps) {
@@ -100,7 +102,7 @@ export default function Navbar({
 
         <Button variant="outline" size="sm" onClick={() => setIsApiSettingsOpen(true)}>
           <Settings className="mr-2 h-4 w-4" />
-          API Gemini
+          APIs
         </Button>
 
         <Button variant="ghost" size="sm" onClick={() => setShortcutsModalOpen(true)} className="text-muted-foreground">

--- a/components/segment-translator.tsx
+++ b/components/segment-translator.tsx
@@ -107,7 +107,14 @@ const SegmentTranslator = memo(
         // Obter a URL da API do LibreTranslate das props
         const libreApiUrl = apiSettings?.libreApiUrl
 
-        const result = await translateText(segment.source, sourceLang, targetLang, libreApiUrl)
+        const result = await translateText(
+          segment.source,
+          sourceLang,
+          targetLang,
+          undefined,
+          undefined,
+          undefined,
+        )
 
         if (result.success && result.translation) {
           setSuggestion(result.translation)

--- a/components/segmented-translator.tsx
+++ b/components/segmented-translator.tsx
@@ -282,8 +282,15 @@ export default function SegmentedTranslator({
         )
 
         try {
-          // Passar a URL da API do LibreTranslate para a função translateText
-          const result = await translateText(segment.source, sourceLang, targetLang, apiSettings?.libreApiUrl)
+          // Chaves de API podem ser fornecidas nas configurações
+          const result = await translateText(
+            segment.source,
+            sourceLang,
+            targetLang,
+            apiSettings?.geminiApiKey,
+            apiSettings?.openaiApiKey,
+            apiSettings?.anthropicApiKey,
+          )
           console.log(`Resultado da tradução:`, result)
 
           if (result.success && result.translation) {

--- a/components/translation-suggestions.tsx
+++ b/components/translation-suggestions.tsx
@@ -34,7 +34,14 @@ export default function TranslationSuggestions({
     setError(null)
 
     try {
-      const result = await translateText(sourceText, sourceLang, targetLang)
+      const result = await translateText(
+        sourceText,
+        sourceLang,
+        targetLang,
+        undefined,
+        undefined,
+        undefined,
+      )
 
       if (result.success && result.translation) {
         setSuggestion(result.translation)

--- a/components/translation/segment-translator.tsx
+++ b/components/translation/segment-translator.tsx
@@ -28,7 +28,7 @@ interface SegmentTranslatorProps {
   onActivate: () => void
   glossaryTerms?: GlossaryTerm[]
   isFailedSegment?: boolean
-  apiSettings?: { geminiApiKey?: string }
+  apiSettings?: { geminiApiKey?: string; openaiApiKey?: string; anthropicApiKey?: string }
 }
 
 // Usar memo para evitar renderizações desnecessárias
@@ -104,10 +104,18 @@ const SegmentTranslator = memo(
       setTranslationError(null)
 
       try {
-        // Obter a chave da API do Gemini das props
         const geminiApiKey = apiSettings?.geminiApiKey
+        const openaiApiKey = apiSettings?.openaiApiKey
+        const anthropicApiKey = apiSettings?.anthropicApiKey
 
-        const result = await translateText(segment.source, sourceLang, targetLang, geminiApiKey)
+        const result = await translateText(
+          segment.source,
+          sourceLang,
+          targetLang,
+          geminiApiKey,
+          openaiApiKey,
+          anthropicApiKey,
+        )
 
         if (result.success && result.translation) {
           setSuggestion(result.translation)

--- a/hooks/use-segmented-translator.ts
+++ b/hooks/use-segmented-translator.ts
@@ -248,8 +248,15 @@ export function useSegmentedTranslator({
         )
 
         try {
-          // Passar a chave da API do Gemini para a função translateText
-          const result = await translateText(segment.source, sourceLang, targetLang, apiSettings?.geminiApiKey)
+          // Passar as chaves de API configuradas para a função translateText
+          const result = await translateText(
+            segment.source,
+            sourceLang,
+            targetLang,
+            apiSettings?.geminiApiKey,
+            apiSettings?.openaiApiKey,
+            apiSettings?.anthropicApiKey,
+          )
           console.log(`Resultado da tradução:`, result)
 
           if (result.success && result.translation) {

--- a/utils/anthropic-service.ts
+++ b/utils/anthropic-service.ts
@@ -1,0 +1,130 @@
+import { ERROR_TYPES } from "./constants"
+import { ErrorService } from "./error-service"
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+const ANTHROPIC_MODEL = "claude-3-sonnet-20240229"
+
+export async function translateWithAnthropic(
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  apiKey: string,
+) {
+  if (!text.trim()) {
+    return {
+      success: false,
+      message: "No text provided",
+      error: ErrorService.createError(
+        ERROR_TYPES.VALIDATION,
+        "Texto vazio para tradução",
+      ),
+    }
+  }
+
+  if (!apiKey) {
+    return {
+      success: false,
+      message: "API key is required",
+      error: ErrorService.createError(
+        ERROR_TYPES.VALIDATION,
+        "Chave de API da Anthropic não fornecida",
+      ),
+    }
+  }
+
+  try {
+    const sourceLanguageName = getLanguageName(sourceLang)
+    const targetLanguageName = getLanguageName(targetLang)
+
+    const prompt = `Traduza este texto do ${sourceLanguageName} para ${targetLanguageName}. Mantenha a formatação original, incluindo quebras de linha e espaços. Retorne apenas o texto traduzido, sem comentários adicionais:\n\n${text}`
+
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: ANTHROPIC_MODEL,
+        max_tokens: 4096,
+        temperature: 0.2,
+        messages: [
+          { role: "user", content: prompt },
+        ],
+      }),
+    })
+
+    const data = await response.json()
+
+    if (response.ok && data.content && data.content.length > 0) {
+      const translatedText = data.content[0].text as string
+      const cleanedTranslation = cleanTranslation(translatedText)
+      return {
+        success: true,
+        translation: cleanedTranslation,
+        provider: "anthropic",
+      }
+    } else {
+      console.error("Erro na API da Anthropic:", data)
+      return {
+        success: false,
+        message: `Erro na API da Anthropic: ${JSON.stringify(data.error || "Erro desconhecido")}`,
+        error: ErrorService.createError(
+          ERROR_TYPES.API,
+          `Erro na API da Anthropic: ${data.error?.message || "Erro desconhecido"}`,
+          data,
+        ),
+      }
+    }
+  } catch (error) {
+    console.error("Erro ao chamar a API da Anthropic:", error)
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Erro desconhecido",
+      error: ErrorService.createError(
+        ERROR_TYPES.NETWORK,
+        error instanceof Error ? error.message : "Erro desconhecido",
+        { error },
+      ),
+    }
+  }
+}
+
+function getLanguageName(langCode: string): string {
+  const languageMap: Record<string, string> = {
+    en: "inglês",
+    pt: "português",
+    es: "espanhol",
+    fr: "francês",
+    de: "alemão",
+    it: "italiano",
+    ja: "japonês",
+    zh: "chinês",
+    ru: "russo",
+    ar: "árabe",
+  }
+
+  return languageMap[langCode] || langCode
+}
+
+function cleanTranslation(text: string): string {
+  const prefixesToRemove = [
+    "Aqui está a tradução:",
+    "Tradução:",
+    "Texto traduzido:",
+    "Here's the translation:",
+    "Translation:",
+    "Translated text:",
+  ]
+
+  let cleanedText = text.trim()
+
+  for (const prefix of prefixesToRemove) {
+    if (cleanedText.startsWith(prefix)) {
+      cleanedText = cleanedText.substring(prefix.length).trim()
+    }
+  }
+
+  return cleanedText
+}

--- a/utils/openai-service.ts
+++ b/utils/openai-service.ts
@@ -1,0 +1,125 @@
+import { ERROR_TYPES } from "./constants"
+import { ErrorService } from "./error-service"
+
+const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+const OPENAI_MODEL = "gpt-4o"
+
+export async function translateWithOpenAI(
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  apiKey: string,
+) {
+  if (!text.trim()) {
+    return {
+      success: false,
+      message: "No text provided",
+      error: ErrorService.createError(
+        ERROR_TYPES.VALIDATION,
+        "Texto vazio para tradução",
+      ),
+    }
+  }
+
+  if (!apiKey) {
+    return {
+      success: false,
+      message: "API key is required",
+      error: ErrorService.createError(
+        ERROR_TYPES.VALIDATION,
+        "Chave de API do OpenAI não fornecida",
+      ),
+    }
+  }
+
+  try {
+    const sourceLanguageName = getLanguageName(sourceLang)
+    const targetLanguageName = getLanguageName(targetLang)
+
+    const prompt = `Traduza este texto do ${sourceLanguageName} para ${targetLanguageName}. Mantenha a formatação original, incluindo quebras de linha e espaços. Retorne apenas o texto traduzido, sem comentários adicionais:\n\n${text}`
+
+    const response = await fetch(OPENAI_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        messages: [
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.2,
+        max_tokens: 8192,
+      }),
+    })
+
+    const data = await response.json()
+
+    if (response.ok && data.choices && data.choices.length > 0) {
+      const translatedText = data.choices[0].message.content as string
+      const cleanedTranslation = cleanTranslation(translatedText)
+      return { success: true, translation: cleanedTranslation, provider: "openai" }
+    } else {
+      console.error("Erro na API do OpenAI:", data)
+      return {
+        success: false,
+        message: `Erro na API do OpenAI: ${JSON.stringify(data.error || "Erro desconhecido")}`,
+        error: ErrorService.createError(
+          ERROR_TYPES.API,
+          `Erro na API do OpenAI: ${data.error?.message || "Erro desconhecido"}`,
+          data,
+        ),
+      }
+    }
+  } catch (error) {
+    console.error("Erro ao chamar a API do OpenAI:", error)
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Erro desconhecido",
+      error: ErrorService.createError(
+        ERROR_TYPES.NETWORK,
+        error instanceof Error ? error.message : "Erro desconhecido",
+        { error },
+      ),
+    }
+  }
+}
+
+function getLanguageName(langCode: string): string {
+  const languageMap: Record<string, string> = {
+    en: "inglês",
+    pt: "português",
+    es: "espanhol",
+    fr: "francês",
+    de: "alemão",
+    it: "italiano",
+    ja: "japonês",
+    zh: "chinês",
+    ru: "russo",
+    ar: "árabe",
+  }
+
+  return languageMap[langCode] || langCode
+}
+
+function cleanTranslation(text: string): string {
+  const prefixesToRemove = [
+    "Aqui está a tradução:",
+    "Tradução:",
+    "Texto traduzido:",
+    "Here's the translation:",
+    "Translation:",
+    "Translated text:",
+  ]
+
+  let cleanedText = text.trim()
+
+  for (const prefix of prefixesToRemove) {
+    if (cleanedText.startsWith(prefix)) {
+      cleanedText = cleanedText.substring(prefix.length).trim()
+    }
+  }
+
+  return cleanedText
+}


### PR DESCRIPTION
## Summary
- add OpenAI and Anthropic translation services
- support the new keys in the translation action
- allow configuring all keys in API settings modal
- update navbar and page to handle new API settings
- pass API keys through translation hooks and components

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db03ae7d08333a6ec1e478aa8c695