### PR TITLE
Add translation provider selection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ export default function TranslationPlatform() {
   const [glossaryTerms, setGlossaryTerms] = useState<GlossaryTerm[]>([])
   const [isLoadingGlossary, setIsLoadingGlossary] = useState(false)
   const [apiSettings, setApiSettings] = useState<ApiSettings>({
+    provider: "gemini",
     geminiApiKey: "",
     openaiApiKey: "",
     anthropicApiKey: "",
@@ -48,7 +49,7 @@ export default function TranslationPlatform() {
     if (savedSettings) {
       try {
         const parsedSettings = JSON.parse(savedSettings)
-        setApiSettings(parsedSettings)
+        setApiSettings({ provider: "gemini", ...parsedSettings })
       } catch (error) {
         console.error("Erro ao carregar configurações de API:", error)
       }
@@ -184,7 +185,9 @@ export default function TranslationPlatform() {
 
   // Verificar se a chave de API está configurada
   const isApiKeyConfigured = Boolean(
-    apiSettings.geminiApiKey || apiSettings.openaiApiKey || apiSettings.anthropicApiKey,
+    (apiSettings.provider === "gemini" && apiSettings.geminiApiKey) ||
+      (apiSettings.provider === "openai" && apiSettings.openaiApiKey) ||
+      (apiSettings.provider === "anthropic" && apiSettings.anthropicApiKey),
   )
 
   return (

--- a/components/api-settings-modal.tsx
+++ b/components/api-settings-modal.tsx
@@ -5,6 +5,13 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { AlertCircle, Check, ExternalLink } from "lucide-react"
 
 interface ApiSettingsModalProps {
@@ -15,6 +22,7 @@ interface ApiSettingsModalProps {
 }
 
 export interface ApiSettings {
+  provider: "gemini" | "openai" | "anthropic"
   geminiApiKey: string
   openaiApiKey: string
   anthropicApiKey: string
@@ -24,6 +32,7 @@ export interface ApiSettings {
 export default function ApiSettingsModal({ isOpen, onClose, onSaveSettings, currentSettings }: ApiSettingsModalProps) {
   const [settings, setSettings] = useState<ApiSettings>({
     ...currentSettings,
+    provider: currentSettings.provider || "gemini",
     geminiApiKey: currentSettings.geminiApiKey || "",
     openaiApiKey: currentSettings.openaiApiKey || "",
     anthropicApiKey: currentSettings.anthropicApiKey || "",
@@ -95,6 +104,25 @@ export default function ApiSettingsModal({ isOpen, onClose, onSaveSettings, curr
         </DialogHeader>
 
         <div className="space-y-4 mt-4">
+          <div className="space-y-2">
+            <Label htmlFor="provider-select">Provedor de Tradução</Label>
+            <Select
+              value={settings.provider}
+              onValueChange={(value) =>
+                setSettings({ ...settings, provider: value as "gemini" | "openai" | "anthropic" })
+              }
+            >
+              <SelectTrigger id="provider-select" className="w-full">
+                <SelectValue placeholder="Selecione o provedor" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="gemini">Google Gemini</SelectItem>
+                <SelectItem value="openai">OpenAI</SelectItem>
+                <SelectItem value="anthropic">Anthropic</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
           <div className="space-y-2">
             <Label htmlFor="gemini-api-key">Chave de API do Google Gemini</Label>
             <Input

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -27,6 +27,7 @@ export default function Navbar({
   onUpdateApiSettings,
   onClearWork,
   apiSettings = {
+    provider: "gemini",
     geminiApiKey: "AIzaSyB5ANmjzUj251i2G3FHgV7UEV9NH4OwT18",
     openaiApiKey: "",
     anthropicApiKey: "",

--- a/components/segment-translator.tsx
+++ b/components/segment-translator.tsx
@@ -114,6 +114,7 @@ const SegmentTranslator = memo(
           undefined,
           undefined,
           undefined,
+          "gemini",
         )
 
         if (result.success && result.translation) {

--- a/components/segmented-translator.tsx
+++ b/components/segmented-translator.tsx
@@ -290,6 +290,7 @@ export default function SegmentedTranslator({
             apiSettings?.geminiApiKey,
             apiSettings?.openaiApiKey,
             apiSettings?.anthropicApiKey,
+            apiSettings?.provider || "gemini",
           )
           console.log(`Resultado da tradução:`, result)
 

--- a/components/translation-suggestions.tsx
+++ b/components/translation-suggestions.tsx
@@ -41,6 +41,7 @@ export default function TranslationSuggestions({
         undefined,
         undefined,
         undefined,
+        "gemini",
       )
 
       if (result.success && result.translation) {

--- a/components/translation/segment-translator.tsx
+++ b/components/translation/segment-translator.tsx
@@ -107,6 +107,7 @@ const SegmentTranslator = memo(
         const geminiApiKey = apiSettings?.geminiApiKey
         const openaiApiKey = apiSettings?.openaiApiKey
         const anthropicApiKey = apiSettings?.anthropicApiKey
+        const provider = apiSettings?.provider || "gemini"
 
         const result = await translateText(
           segment.source,
@@ -115,6 +116,7 @@ const SegmentTranslator = memo(
           geminiApiKey,
           openaiApiKey,
           anthropicApiKey,
+          provider,
         )
 
         if (result.success && result.translation) {

--- a/hooks/use-segment.ts
+++ b/hooks/use-segment.ts
@@ -106,7 +106,15 @@ export function useSegment({
       // Obter a URL da API do LibreTranslate das props
       const libreApiUrl = apiSettings?.libreApiUrl
 
-      const result = await translateText(segment.source, sourceLang, targetLang, libreApiUrl)
+      const result = await translateText(
+        segment.source,
+        sourceLang,
+        targetLang,
+        libreApiUrl,
+        undefined,
+        undefined,
+        "gemini",
+      )
 
       if (result.success && result.translation) {
         setSuggestion(result.translation)

--- a/hooks/use-segmented-translator.ts
+++ b/hooks/use-segmented-translator.ts
@@ -256,6 +256,7 @@ export function useSegmentedTranslator({
             apiSettings?.geminiApiKey,
             apiSettings?.openaiApiKey,
             apiSettings?.anthropicApiKey,
+            apiSettings?.provider || "gemini",
           )
           console.log(`Resultado da tradução:`, result)
 


### PR DESCRIPTION
## Summary
- add dropdown to choose translation API provider
- save provider choice alongside API keys in local storage
- use chosen provider when translating text

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685db315f4d88333ab0ee7c5112348a6